### PR TITLE
Add idotless_dotbelowcomb idotless_ogonekcomb and ccmp_SoftDotted lookup

### DIFF
--- a/sources/PoltawskiNowy-Italic.glyphs
+++ b/sources/PoltawskiNowy-Italic.glyphs
@@ -123,6 +123,14 @@ lookup ccmp_latn_2;
 tag = ccmp;
 },
 {
+code = "lookup ccmp_SoftDotted {
+	sub [idotbelow iogonek]' @CombiningTopAccents by [idotless_dotbelowcomb idotless_ogonekcomb];
+	sub [idotbelow iogonek]' @CombiningNonTopAccents @CombiningTopAccents by [idotless_dotbelowcomb idotless_ogonekcomb];
+} ccmp_SoftDotted;
+";
+tag = ccmp;
+},
+{
 automatic = 1;
 code = "lookup locl_latn_0 {
 	script latn;
@@ -30901,6 +30909,68 @@ width = 314;
 }
 );
 unicode = 305;
+},
+{
+glyphname = idotless_dotbelowcomb;
+layers = (
+{
+layerId = "45069982-2EFC-4B7D-8C53-1932E6EAC4CA";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (162,0);
+ref = dotbelowcomb;
+}
+);
+width = 294;
+},
+{
+layerId = "503E420B-61F7-4277-A1BE-A8852071B452";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (171,0);
+ref = dotbelowcomb;
+}
+);
+width = 314;
+}
+);
+},
+{
+glyphname = idotless_ogonekcomb;
+layers = (
+{
+layerId = "45069982-2EFC-4B7D-8C53-1932E6EAC4CA";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (221,0);
+ref = ogonekcomb;
+}
+);
+width = 294;
+},
+{
+layerId = "503E420B-61F7-4277-A1BE-A8852071B452";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (230,0);
+ref = ogonekcomb;
+}
+);
+width = 314;
+}
+);
 },
 {
 color = 10;

--- a/sources/PoltawskiNowy.glyphs
+++ b/sources/PoltawskiNowy.glyphs
@@ -138,6 +138,13 @@ lookup ccmp_latn_2;
 tag = ccmp;
 },
 {
+code = "lookup ccmp_SoftDotted {
+	sub [idotbelow iogonek]' @CombiningTopAccents by [idotless_dotbelowcomb idotless_ogonekcomb];
+	sub [idotbelow iogonek]' @CombiningNonTopAccents @CombiningTopAccents by [idotless_dotbelowcomb idotless_ogonekcomb];
+} ccmp_SoftDotted;";
+tag = ccmp;
+},
+{
 automatic = 1;
 code = "lookup locl_latn_0 {
 	script latn;
@@ -30935,6 +30942,68 @@ width = 318;
 }
 );
 unicode = 305;
+},
+{
+glyphname = idotless_dotbelowcomb;
+layers = (
+{
+layerId = "45069982-2EFC-4B7D-8C53-1932E6EAC4CA";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (155,0);
+ref = dotbelowcomb;
+}
+);
+width = 303;
+},
+{
+layerId = "503E420B-61F7-4277-A1BE-A8852071B452";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (162,0);
+ref = dotbelowcomb;
+}
+);
+width = 318;
+}
+);
+},
+{
+glyphname = idotless_ogonekcomb;
+layers = (
+{
+layerId = "45069982-2EFC-4B7D-8C53-1932E6EAC4CA";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (230,0);
+ref = ogonekcomb;
+}
+);
+width = 303;
+},
+{
+layerId = "503E420B-61F7-4277-A1BE-A8852071B452";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (252,0);
+ref = ogonekcomb;
+}
+);
+width = 318;
+}
+);
 },
 {
 color = 10;


### PR DESCRIPTION
ị and į lose their dots like i or j when combined with a top mark that replaces the dot.